### PR TITLE
Housekeeping: normalize post-release state

### DIFF
--- a/.github/workflows/dependency-refresh-tests.yml
+++ b/.github/workflows/dependency-refresh-tests.yml
@@ -3,7 +3,7 @@ name: Dependency Refresh Tests
 on:
   push:
     branches:
-      - feature/47-timing-2.2.4-dependency-refresh
+      - main
   pull_request:
     branches:
       - main

--- a/ESPRESSIO_DEPENDENCY_CHART.md
+++ b/ESPRESSIO_DEPENDENCY_CHART.md
@@ -47,16 +47,16 @@ EXECUTION
 
 TRANSPORT / EVENT
 ├── Sockets 0.5.0
-├── ESP-Now 0.5.2 (planned downstream refresh)
-└── Event 5.8.2 (planned downstream convergence)
+├── ESP-Now 0.5.2
+└── Event 5.8.2
 
 DIAGNOSTICS / OPERATOR
-└── Serial 0.5.1 (release candidate)
+└── Serial 0.5.1
 ```
 
 ## Downstream consumers
 
-Event 5.8.2 will consume Threads 3.1.4 as a required dependency. Serial 0.5.1
+Event 5.8.2 consumes Threads 3.1.4 as a required dependency. Serial 0.5.1
 may consume Threads directly only through its opt-in diagnostic integration.
 
 Threads itself remains independent of Event and Serial.


### PR DESCRIPTION
## Summary
- refresh the dependency chart to the completed Timing 2.2.4 / Event 5.8.2 generation
- remove stale planned/release-candidate wording
- normalize CI triggers to `main` pushes and pull requests

No library version, dependency constraint, API, or runtime behavior changes.