### PR TITLE
README.MD enhancements (#53)

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ You can quickly and easily add this library to your project in PlatformIO by sim
 
 ```ini
 lib_deps =
-    flowduino/ESPressio-Threads@^3.1.3
+    flowduino/ESPressio-Threads@^3.1.4
 ```
 
 Alternatively, if you want to use the bleeding-edge (effectively "Developer Integration Testing" or "DIT") sources, you can instead use:


### PR DESCRIPTION
Corrects the stale PlatformIO installation example from `flowduino/ESPressio-Threads@^3.1.3` to the current `^3.1.4` source/release generation while preserving the complete existing 1,260-line README and its in-depth usage/reference material.

The public-API audit found the existing README already covers the current Threads surface comprehensively, so no filler sections were added.

This PR is based on the README restoration-audit branch and contains only the accuracy correction.

Tracks #53.